### PR TITLE
Automatically reconnect when there is a TLS error

### DIFF
--- a/src/common/server.c
+++ b/src/common/server.c
@@ -657,6 +657,9 @@ conn_fail:
 
 			server_cleanup (serv);
 
+			if (prefs.hex_net_auto_reconnectonfail)
+				auto_reconnect (serv, FALSE, -1);
+
 			return (0);
 		}
 


### PR DESCRIPTION
The next server in the rotation probably will have working TLS.

Fixes: https://github.com/hexchat/hexchat/issues/475